### PR TITLE
Build a denylist for processed datasets to avoid re-prompting previous samples [ENG-431]

### DIFF
--- a/opencompass/datasets/base.py
+++ b/opencompass/datasets/base.py
@@ -1,9 +1,12 @@
 from abc import abstractstaticmethod
-from typing import Dict, Optional, Union
+import json
+import os
+from typing import Dict, Optional, Union, List
 
 from datasets import Dataset, DatasetDict
 
 from opencompass.openicl import DatasetReader
+from opencompass.utils import get_logger
 
 
 class BaseDataset:
@@ -17,12 +20,44 @@ class BaseDataset:
 
     @property
     def train(self):
-        return self.reader.dataset['train']
+        return self.reader.dataset["train"]
 
     @property
     def test(self):
-        return self.reader.dataset['test']
+        return self.reader.dataset["test"]
 
     @abstractstaticmethod
     def load(**kwargs) -> Union[Dataset, DatasetDict]:
         pass
+
+    @staticmethod
+    def build_denylist(training_path: str, dataset_abbr: str) -> Dict[str, List[str]]:
+        """
+        Take a file path to training samples for OOB, load them and identify previously-prompted samples.
+        Do not re-prompt these samples.
+        """
+        logger = get_logger(log_level="INFO")
+        model_to_denylist = {}
+        for entry in os.scandir(training_path):
+            for model in os.scandir(entry.path):
+
+                if not model.is_dir():
+                    logger.debug(f"Skipping non-directory model {model.path}")
+                    continue
+
+                for eval_dataset in os.scandir(model.path):
+                    if dataset_abbr not in eval_dataset.name:
+                        logger.debug(
+                            f"Skipping dataset file {eval_dataset.path} - not a {dataset_abbr} file."
+                        )
+                        continue
+
+                    with open(eval_dataset.path) as f:
+                        sample_data = json.load(f)
+                        if "denylist" in sample_data:
+                            model_to_denylist[model.name] = sample_data["denylist"]
+
+        logger.info(
+            f"Identified denylist samples for {dataset_abbr} datasets: {model_to_denylist}"
+        )
+        return model_to_denylist

--- a/opencompass/datasets/base.py
+++ b/opencompass/datasets/base.py
@@ -36,7 +36,7 @@ class BaseDataset:
         Take a file path to training samples for OOB, load them and identify previously-prompted samples.
         Do not re-prompt these samples.
         """
-        logger = get_logger(log_level="DEBUG")
+        logger = get_logger(log_level="INFO")
         model_to_denylist = {}
         for dirpath, dirnames, filenames in os.walk(training_path, topdown=False):
             if len(dirnames) > 0:

--- a/opencompass/datasets/base.py
+++ b/opencompass/datasets/base.py
@@ -35,6 +35,12 @@ class BaseDataset:
         """
         Take a file path to training samples for OOB, load them and identify previously-prompted samples.
         Do not re-prompt these samples.
+
+        Usage instructions:
+        1. For each eval dataset, call this method on the training directory
+        2. Write the model-to-denylist mapping to the eval dataset file in the training directory
+        3. Reference the denylist in `read_data.get_samples_from_local_dataset` to avoid re-prompting
+
         """
         logger = get_logger(log_level="INFO")
         model_to_denylist = {}
@@ -52,8 +58,7 @@ class BaseDataset:
 
                 with open(f"{dirpath}/{filename}", "r") as f:
                     sample_data = json.load(f)
-                    if "denylist" in sample_data:
-                        model_to_denylist[model_name] = sample_data["denylist"]
+                    model_to_denylist[model_name] = list(sample_data.keys())
 
         logger.info(
             f"Identified denylist samples for {dataset_abbr} datasets: {model_to_denylist}"

--- a/opencompass/datasets/base.py
+++ b/opencompass/datasets/base.py
@@ -58,9 +58,9 @@ class BaseDataset:
 
                 with open(f"{dirpath}/{filename}", "r") as f:
                     sample_data = json.load(f)
-                    model_to_denylist[model_name] = list(sample_data.keys())
+                    model_to_denylist[model_name] = list(set(sample_data.keys()))
 
         logger.info(
-            f"Identified denylist samples for {dataset_abbr} datasets: {model_to_denylist}"
+            f"Identified denylist samples for {dataset_abbr} datasets across {len(model_to_denylist)} models."
         )
         return model_to_denylist

--- a/opencompass/datasets/notdiamond/read_data.py
+++ b/opencompass/datasets/notdiamond/read_data.py
@@ -2,6 +2,7 @@ import json
 import random
 from typing import Union
 
+
 def get_samples_from_local_dataset(path: str, size: int, seed: Union[int, str]) -> dict:
     random.seed(seed)
 
@@ -11,6 +12,12 @@ def get_samples_from_local_dataset(path: str, size: int, seed: Union[int, str]) 
     n_samples = len(eval_data.keys())
     if n_samples < size:
         size = n_samples
+
+    denylist_ids = eval_data.get("denylist", [])
+    if len(denylist_ids) > 0:
+        for deny_id in denylist_ids:
+            eval_data.pop(deny_id)
+
     sample_ids = random.sample(list(eval_data.keys()), size)
     samples = {}
     for sample_id in sample_ids:

--- a/opencompass/openicl/icl_evaluator/icl_notdiamond_evaluator.py
+++ b/opencompass/openicl/icl_evaluator/icl_notdiamond_evaluator.py
@@ -362,7 +362,7 @@ class NDRougeEvaluator(BaseEvaluator):
 
 
 @ICL_EVALUATORS.register_module()
-class NDMATHEvaluator(MATHEvaluator):
+class NDMATHEvaluator(BaseEvaluator):
 
     def __init__(self, *args, **kwargs):
         super(NDMATHEvaluator, self).__init__(*args, **kwargs)

--- a/tests/dataset/test_base_dataset.py
+++ b/tests/dataset/test_base_dataset.py
@@ -4,6 +4,6 @@ from opencompass.datasets.base import BaseDataset
 def test_base_dataset_build_denylist():
     eval_directory = "tests/fixtures/build_denylist"
     model_to_denylist = BaseDataset.build_denylist(eval_directory, "mgsm")
-    print(model_to_denylist)
-    assert len(model_to_denylist) == 1
-    assert len(model_to_denylist["gpt-4"]) == 1
+    assert len(model_to_denylist) == 2
+    assert len(model_to_denylist["gpt-4"]) == 2
+    assert len(model_to_denylist["gpt-4-1106-preview"]) == 2

--- a/tests/dataset/test_base_dataset.py
+++ b/tests/dataset/test_base_dataset.py
@@ -2,11 +2,8 @@ from opencompass.datasets.base import BaseDataset
 
 
 def test_base_dataset_build_denylist():
-    # Create mock or temp dir structure
-
-    # Add json file for two models - one has a denylist, the other does not
-
-    # Call build_denylist for the dataset with the denylist
-
-    # Ensure the denylist is returned
-    assert False
+    eval_directory = "tests/fixtures/build_denylist"
+    model_to_denylist = BaseDataset.build_denylist(eval_directory, "mgsm")
+    print(model_to_denylist)
+    assert len(model_to_denylist) == 1
+    assert len(model_to_denylist["gpt-4"]) == 1

--- a/tests/dataset/test_base_dataset.py
+++ b/tests/dataset/test_base_dataset.py
@@ -1,0 +1,12 @@
+from opencompass.datasets.base import BaseDataset
+
+
+def test_base_dataset_build_denylist():
+    # Create mock or temp dir structure
+
+    # Add json file for two models - one has a denylist, the other does not
+
+    # Call build_denylist for the dataset with the denylist
+
+    # Ensure the denylist is returned
+    assert False

--- a/tests/openicl/test_icl_notdiamond_evaluator.py
+++ b/tests/openicl/test_icl_notdiamond_evaluator.py
@@ -1,0 +1,9 @@
+import pytest
+
+from opencompass.opencompass.openicl.icl_evaluator.icl_notdiamond_evaluator import (
+    NDMgsmEvaluator,
+)
+
+
+def test_mgsm_evaluator(mgsm_example):
+    assert False


### PR DESCRIPTION
We have many, many model-to-sample checks to perform while finishing ENG-431. Let's save ourselves money wherever possible by skipping samples we've already used to prompt a given model.

The new method `build_denylist` returns a map from model to list of sample IDs. When we prepare to prompt an LLM with the sub-sample of an eval dataset, we can then use this map to skip samples.