### PR TITLE
Adding NDNaivePartitioner to shuffle tasks.

### DIFF
--- a/opencompass/partitioners/__init__.py
+++ b/opencompass/partitioners/__init__.py
@@ -2,3 +2,4 @@ from .mm_naive import *  # noqa: F401, F403
 from .naive import *  # noqa: F401, F403
 from .num_worker import *  # noqa: F401, F403
 from .size import *  # noqa: F401, F403
+from .nd_naive import *

--- a/opencompass/partitioners/nd_naive.py
+++ b/opencompass/partitioners/nd_naive.py
@@ -1,0 +1,86 @@
+import os.path as osp
+import random
+from typing import Dict, List, Optional
+
+from mmengine.config import Config, ConfigDict
+
+from opencompass.registry import PARTITIONERS
+from opencompass.utils import get_infer_output_path
+
+from .base import BasePartitioner
+
+
+@PARTITIONERS.register_module()
+class NDNaivePartitioner(BasePartitioner):
+    """Naive task partitioner. This partitioner will generate a task for each n
+    model-dataset pairs.
+
+    Args:
+        out_dir (str): The output directory of tasks.
+        n (int): The number of model-dataset pairs in each task.
+        keep_keys (List[str]): The keys to be kept from the experiment config
+            to the task config.
+    """
+
+    def __init__(self, out_dir: str, n: int = 1, keep_keys: Optional[List[str]] = None):
+        super().__init__(out_dir=out_dir, keep_keys=keep_keys)
+        self.n = n
+
+    def partition(
+        self,
+        model_dataset_combinations: List[Dict[str, List[ConfigDict]]],
+        work_dir: str,
+        out_dir: str,
+        add_cfg: Dict = {},
+    ) -> List[Dict]:
+        """Partition model-dataset pairs into tasks. Each task is defined as a
+        dict and will run independently as a unit. Its structure is as
+        follows:
+
+        .. code-block:: python
+
+            {
+                'models': [],  # a list of model configs
+                'datasets': [[]],  # a nested list of dataset configs, each
+                                    list corresponds to a model
+                'work_dir': '',  # the work dir
+            }
+
+        Unlike the base NaivePartitioner, this partitioner will shuffle the combination of models
+        and datsets before creating each one.
+
+        Args:
+            model_dataset_combinations (List[Dict]): List of
+                `{models: [...], datasets: [...]}` dicts. Each dict contains
+                a list of model configs and a list of dataset configs.
+            work_dir (str): The work dir for the task.
+            out_dir (str): The full output path for the task, intended for
+                Partitioners to check whether the task is finished via the
+                existency of result file in this directory.
+
+        Returns:
+            List[Dict]: A list of tasks.
+        """
+
+        tasks = []
+        for comb in model_dataset_combinations:
+            for model in comb["models"]:
+                chunks = []
+                for dataset in comb["datasets"]:
+                    filename = get_infer_output_path(model, dataset, out_dir)
+                    if osp.exists(filename):
+                        continue
+                    chunks.append(dataset)
+
+                for i in range(0, len(chunks), self.n):
+                    task = Config(
+                        {
+                            "models": [model],
+                            "datasets": [chunks[i : i + self.n]],
+                            "work_dir": work_dir,
+                            **add_cfg,
+                        }
+                    )
+                    tasks.append(task)
+        random.shuffle(tasks)
+        return tasks

--- a/opencompass/partitioners/nd_naive.py
+++ b/opencompass/partitioners/nd_naive.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional
 from mmengine.config import Config, ConfigDict
 
 from opencompass.registry import PARTITIONERS
-from opencompass.utils import get_infer_output_path
+from opencompass.utils import get_infer_output_path, get_logger
 
 from .base import BasePartitioner
 
@@ -22,9 +22,12 @@ class NDNaivePartitioner(BasePartitioner):
             to the task config.
     """
 
-    def __init__(self, out_dir: str, n: int = 1, keep_keys: Optional[List[str]] = None):
+    def __init__(
+        self, out_dir: str, n: int = 1, keep_keys: Optional[List[str]] = None, **kwargs
+    ):
         super().__init__(out_dir=out_dir, keep_keys=keep_keys)
         self.n = n
+        get_logger().warn(f"Ignoring kwargs passed to NDNaivePartitioner: {kwargs}")
 
     def partition(
         self,

--- a/opencompass/utils/run.py
+++ b/opencompass/utils/run.py
@@ -5,7 +5,11 @@ import tabulate
 from mmengine.config import Config
 
 from opencompass.datasets.custom import make_custom_dataset_config
-from opencompass.partitioners import NaivePartitioner, SizePartitioner
+from opencompass.partitioners import (
+    NaivePartitioner,
+    SizePartitioner,
+    NDNaivePartitioner,
+)
 from opencompass.runners import DLCRunner, LocalRunner, SlurmRunner
 from opencompass.tasks import OpenICLEvalTask, OpenICLInferTask
 from opencompass.utils import get_logger, match_files
@@ -19,31 +23,29 @@ def match_cfg_file(workdir: str, pattern: Union[str, List[str]]) -> List[str]:
     """
     if isinstance(pattern, str):
         pattern = [pattern]
-    pattern = [p + '.py' if not p.endswith('.py') else p for p in pattern]
+    pattern = [p + ".py" if not p.endswith(".py") else p for p in pattern]
     files = match_files(workdir, pattern, fuzzy=False)
     if len(files) != len(pattern):
         nomatched = []
         ambiguous = []
-        err_msg = ('The provided pattern matches 0 or more than one '
-                   'config. Please verify your pattern and try again. '
-                   'You may use tools/list_configs.py to list or '
-                   'locate the configurations.\n')
+        err_msg = (
+            "The provided pattern matches 0 or more than one "
+            "config. Please verify your pattern and try again. "
+            "You may use tools/list_configs.py to list or "
+            "locate the configurations.\n"
+        )
         for p in pattern:
             files = match_files(workdir, p, fuzzy=False)
             if len(files) == 0:
                 nomatched.append([p[:-3]])
             elif len(files) > 1:
-                ambiguous.append([p[:-3], '\n'.join(f[1] for f in files)])
+                ambiguous.append([p[:-3], "\n".join(f[1] for f in files)])
         if nomatched:
-            table = [['Not matched patterns'], *nomatched]
-            err_msg += tabulate.tabulate(table,
-                                         headers='firstrow',
-                                         tablefmt='psql')
+            table = [["Not matched patterns"], *nomatched]
+            err_msg += tabulate.tabulate(table, headers="firstrow", tablefmt="psql")
         if ambiguous:
-            table = [['Ambiguous patterns', 'Matched files'], *ambiguous]
-            err_msg += tabulate.tabulate(table,
-                                         headers='firstrow',
-                                         tablefmt='psql')
+            table = [["Ambiguous patterns", "Matched files"], *ambiguous]
+            err_msg += tabulate.tabulate(table, headers="firstrow", tablefmt="psql")
         raise ValueError(err_msg)
     return files
 
@@ -58,155 +60,174 @@ def get_config_from_arg(args) -> Config:
     """
     if args.config:
         config = Config.fromfile(args.config, format_python_code=False)
-        for i, dataset in enumerate(config['datasets']):
-            if 'type' not in dataset:
-                config['datasets'][i] = make_custom_dataset_config(dataset)
+        for i, dataset in enumerate(config["datasets"]):
+            if "type" not in dataset:
+                config["datasets"][i] = make_custom_dataset_config(dataset)
         return config
     # parse dataset args
     if not args.datasets and not args.custom_dataset_path:
-        raise ValueError('You must specify "--datasets" or '
-                         '"--custom-dataset-path" if you do not specify a '
-                         'config file path.')
+        raise ValueError(
+            'You must specify "--datasets" or '
+            '"--custom-dataset-path" if you do not specify a '
+            "config file path."
+        )
     datasets = []
     if args.datasets:
-        datasets_dir = os.path.join(args.config_dir, 'datasets')
+        datasets_dir = os.path.join(args.config_dir, "datasets")
         for dataset in match_cfg_file(datasets_dir, args.datasets):
-            get_logger().info(f'Loading {dataset[0]}: {dataset[1]}')
+            get_logger().info(f"Loading {dataset[0]}: {dataset[1]}")
             cfg = Config.fromfile(dataset[1])
             for k in cfg.keys():
-                if k.endswith('_datasets'):
+                if k.endswith("_datasets"):
                     datasets += cfg[k]
     else:
-        dataset = {'path': args.custom_dataset_path}
+        dataset = {"path": args.custom_dataset_path}
         if args.custom_dataset_infer_method is not None:
-            dataset['infer_method'] = args.custom_dataset_infer_method
+            dataset["infer_method"] = args.custom_dataset_infer_method
         if args.custom_dataset_data_type is not None:
-            dataset['data_type'] = args.custom_dataset_data_type
+            dataset["data_type"] = args.custom_dataset_data_type
         if args.custom_dataset_meta_path is not None:
-            dataset['meta_path'] = args.custom_dataset_meta_path
+            dataset["meta_path"] = args.custom_dataset_meta_path
         dataset = make_custom_dataset_config(dataset)
         datasets.append(dataset)
 
     # parse model args
     if not args.models and not args.hf_path:
-        raise ValueError('You must specify a config file path, '
-                         'or specify --models and --datasets, or '
-                         'specify HuggingFace model parameters and '
-                         '--datasets.')
+        raise ValueError(
+            "You must specify a config file path, "
+            "or specify --models and --datasets, or "
+            "specify HuggingFace model parameters and "
+            "--datasets."
+        )
     models = []
     if args.models:
-        model_dir = os.path.join(args.config_dir, 'models')
+        model_dir = os.path.join(args.config_dir, "models")
         for model in match_cfg_file(model_dir, args.models):
-            get_logger().info(f'Loading {model[0]}: {model[1]}')
+            get_logger().info(f"Loading {model[0]}: {model[1]}")
             cfg = Config.fromfile(model[1])
-            if 'models' not in cfg:
+            if "models" not in cfg:
                 raise ValueError(
-                    f'Config file {model[1]} does not contain "models" field')
-            models += cfg['models']
+                    f'Config file {model[1]} does not contain "models" field'
+                )
+            models += cfg["models"]
     else:
         from opencompass.models import HuggingFace
-        model = dict(type=f'{HuggingFace.__module__}.{HuggingFace.__name__}',
-                     path=args.hf_path,
-                     peft_path=args.peft_path,
-                     tokenizer_path=args.tokenizer_path,
-                     model_kwargs=args.model_kwargs,
-                     tokenizer_kwargs=args.tokenizer_kwargs,
-                     max_seq_len=args.max_seq_len,
-                     max_out_len=args.max_out_len,
-                     batch_padding=not args.no_batch_padding,
-                     batch_size=args.batch_size,
-                     pad_token_id=args.pad_token_id,
-                     run_cfg=dict(num_gpus=args.num_gpus))
+
+        model = dict(
+            type=f"{HuggingFace.__module__}.{HuggingFace.__name__}",
+            path=args.hf_path,
+            peft_path=args.peft_path,
+            tokenizer_path=args.tokenizer_path,
+            model_kwargs=args.model_kwargs,
+            tokenizer_kwargs=args.tokenizer_kwargs,
+            max_seq_len=args.max_seq_len,
+            max_out_len=args.max_out_len,
+            batch_padding=not args.no_batch_padding,
+            batch_size=args.batch_size,
+            pad_token_id=args.pad_token_id,
+            run_cfg=dict(num_gpus=args.num_gpus),
+        )
         models.append(model)
     # parse summarizer args
-    summarizer = args.summarizer if args.summarizer is not None else 'example'
-    summarizers_dir = os.path.join(args.config_dir, 'summarizers')
+    summarizer = args.summarizer if args.summarizer is not None else "example"
+    summarizers_dir = os.path.join(args.config_dir, "summarizers")
     s = match_cfg_file(summarizers_dir, [summarizer])[0]
-    get_logger().info(f'Loading {s[0]}: {s[1]}')
+    get_logger().info(f"Loading {s[0]}: {s[1]}")
     cfg = Config.fromfile(s[1])
-    summarizer = cfg['summarizer']
+    summarizer = cfg["summarizer"]
 
-    return Config(dict(models=models, datasets=datasets,
-                       summarizer=summarizer),
-                  format_python_code=False)
+    return Config(
+        dict(models=models, datasets=datasets, summarizer=summarizer),
+        format_python_code=False,
+    )
 
 
 def exec_mm_infer_runner(tasks, args, cfg):
     """execute multimodal infer runner according to args."""
     if args.slurm:
-        runner = SlurmRunner(dict(type='MultimodalInferTask'),
-                             max_num_workers=args.max_num_workers,
-                             partition=args.partition,
-                             quotatype=args.quotatype,
-                             retry=args.retry,
-                             debug=args.debug,
-                             lark_bot_url=cfg['lark_bot_url'])
+        runner = SlurmRunner(
+            dict(type="MultimodalInferTask"),
+            max_num_workers=args.max_num_workers,
+            partition=args.partition,
+            quotatype=args.quotatype,
+            retry=args.retry,
+            debug=args.debug,
+            lark_bot_url=cfg["lark_bot_url"],
+        )
     elif args.dlc:
-        raise NotImplementedError('Currently, we do not support evaluating \
-                             multimodal models on dlc.')
+        raise NotImplementedError(
+            "Currently, we do not support evaluating \
+                             multimodal models on dlc."
+        )
     else:
-        runner = LocalRunner(task=dict(type='MultimodalInferTask'),
-                             max_num_workers=args.max_num_workers,
-                             debug=args.debug,
-                             lark_bot_url=cfg['lark_bot_url'])
+        runner = LocalRunner(
+            task=dict(type="MultimodalInferTask"),
+            max_num_workers=args.max_num_workers,
+            debug=args.debug,
+            lark_bot_url=cfg["lark_bot_url"],
+        )
     runner(tasks)
 
 
 def get_config_type(obj) -> str:
-    return f'{obj.__module__}.{obj.__name__}'
+    return f"{obj.__module__}.{obj.__name__}"
 
 
 def fill_infer_cfg(cfg, args):
-    new_cfg = dict(infer=dict(
-        partitioner=dict(type=get_config_type(SizePartitioner),
-                         max_task_size=args.max_partition_size,
-                         gen_task_coef=args.gen_task_coef),
-        runner=dict(
-            max_num_workers=args.max_num_workers,
-            debug=args.debug,
-            task=dict(type=get_config_type(OpenICLInferTask)),
-            lark_bot_url=cfg['lark_bot_url'],
-        )), )
+    new_cfg = dict(
+        infer=dict(
+            partitioner=dict(
+                type=get_config_type(NDNaivePartitioner),
+                max_task_size=args.max_partition_size,
+                gen_task_coef=args.gen_task_coef,
+            ),
+            runner=dict(
+                max_num_workers=args.max_num_workers,
+                debug=args.debug,
+                task=dict(type=get_config_type(OpenICLInferTask)),
+                lark_bot_url=cfg["lark_bot_url"],
+            ),
+        ),
+    )
     if args.slurm:
-        new_cfg['infer']['runner']['type'] = get_config_type(SlurmRunner)
-        new_cfg['infer']['runner']['partition'] = args.partition
-        new_cfg['infer']['runner']['quotatype'] = args.quotatype
-        new_cfg['infer']['runner']['qos'] = args.qos
-        new_cfg['infer']['runner']['retry'] = args.retry
+        new_cfg["infer"]["runner"]["type"] = get_config_type(SlurmRunner)
+        new_cfg["infer"]["runner"]["partition"] = args.partition
+        new_cfg["infer"]["runner"]["quotatype"] = args.quotatype
+        new_cfg["infer"]["runner"]["qos"] = args.qos
+        new_cfg["infer"]["runner"]["retry"] = args.retry
     elif args.dlc:
-        new_cfg['infer']['runner']['type'] = get_config_type(DLCRunner)
-        new_cfg['infer']['runner']['aliyun_cfg'] = Config.fromfile(
-            args.aliyun_cfg)
-        new_cfg['infer']['runner']['retry'] = args.retry
+        new_cfg["infer"]["runner"]["type"] = get_config_type(DLCRunner)
+        new_cfg["infer"]["runner"]["aliyun_cfg"] = Config.fromfile(args.aliyun_cfg)
+        new_cfg["infer"]["runner"]["retry"] = args.retry
     else:
-        new_cfg['infer']['runner']['type'] = get_config_type(LocalRunner)
-        new_cfg['infer']['runner'][
-            'max_workers_per_gpu'] = args.max_workers_per_gpu
+        new_cfg["infer"]["runner"]["type"] = get_config_type(LocalRunner)
+        new_cfg["infer"]["runner"]["max_workers_per_gpu"] = args.max_workers_per_gpu
     cfg.merge_from_dict(new_cfg)
 
 
 def fill_eval_cfg(cfg, args):
     new_cfg = dict(
-        eval=dict(partitioner=dict(type=get_config_type(NaivePartitioner)),
-                  runner=dict(
-                      max_num_workers=args.max_num_workers,
-                      debug=args.debug,
-                      task=dict(type=get_config_type(OpenICLEvalTask)),
-                      lark_bot_url=cfg['lark_bot_url'],
-                  )))
+        eval=dict(
+            partitioner=dict(type=get_config_type(NDNaivePartitioner)),
+            runner=dict(
+                max_num_workers=args.max_num_workers,
+                debug=args.debug,
+                task=dict(type=get_config_type(OpenICLEvalTask)),
+                lark_bot_url=cfg["lark_bot_url"],
+            ),
+        )
+    )
     if args.slurm:
-        new_cfg['eval']['runner']['type'] = get_config_type(SlurmRunner)
-        new_cfg['eval']['runner']['partition'] = args.partition
-        new_cfg['eval']['runner']['quotatype'] = args.quotatype
-        new_cfg['eval']['runner']['qos'] = args.qos
-        new_cfg['eval']['runner']['retry'] = args.retry
+        new_cfg["eval"]["runner"]["type"] = get_config_type(SlurmRunner)
+        new_cfg["eval"]["runner"]["partition"] = args.partition
+        new_cfg["eval"]["runner"]["quotatype"] = args.quotatype
+        new_cfg["eval"]["runner"]["qos"] = args.qos
+        new_cfg["eval"]["runner"]["retry"] = args.retry
     elif args.dlc:
-        new_cfg['eval']['runner']['type'] = get_config_type(DLCRunner)
-        new_cfg['eval']['runner']['aliyun_cfg'] = Config.fromfile(
-            args.aliyun_cfg)
-        new_cfg['eval']['runner']['retry'] = args.retry
+        new_cfg["eval"]["runner"]["type"] = get_config_type(DLCRunner)
+        new_cfg["eval"]["runner"]["aliyun_cfg"] = Config.fromfile(args.aliyun_cfg)
+        new_cfg["eval"]["runner"]["retry"] = args.retry
     else:
-        new_cfg['eval']['runner']['type'] = get_config_type(LocalRunner)
-        new_cfg['eval']['runner'][
-            'max_workers_per_gpu'] = args.max_workers_per_gpu
+        new_cfg["eval"]["runner"]["type"] = get_config_type(LocalRunner)
+        new_cfg["eval"]["runner"]["max_workers_per_gpu"] = args.max_workers_per_gpu
     cfg.merge_from_dict(new_cfg)


### PR DESCRIPTION
We've been running a full eval dataset pass for over two weeks. Most of this time has been spent bottlenecked on API request throttling.

This PR introduces `NDNaivePartitioner`, which does exactly one thing different from the `NaivePartitioner`: it shuffles the set of tasks before submitting them. This ensures model tasks are not batched together, thereby limiting our likelihood of API request throttling.